### PR TITLE
loads observers at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ To dump the `rossystem` model of the running system started above in Terminal 1 
 # Terminal 2:
 rosrun rosgraph_monitor rossystem_snapshot
 ```
-
+Observers can now be loaded at startup. Below is an example to load `ROSGraphObserver` and `DummyObserver`. `ROSGraphObserver` also needs an additional private parameter `_desired_rossystem` with absolute path of `rossystem` file.
+```
+# Terminal 2:
+rosrun rosgraph_monitor monitor --load ROSGraphObserver DummyObserver _desired_rossystem:=<path/to/file>test.rossystem
+```
 
 ### Property observer
 To use a custom created property observer in the module `observers` (e.g. `QualityObserver`)

--- a/scripts/monitor
+++ b/scripts/monitor
@@ -87,7 +87,18 @@ class ModuleManager(object):
 if __name__ == "__main__":
     rospy.init_node('graph_monitor')
 
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument('--load',
+                        nargs='+',
+                        type=str,
+                        default="",
+                        help='Load observers at startup')
+    args = parser.parse_args()
+
     manager = ModuleManager()
     manager.load_observers()
 
+    if len(args.load) > 0:
+        for obs in args.load:
+            manager.start_observer(obs)
     rospy.spin()

--- a/scripts/monitor
+++ b/scripts/monitor
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import importlib
 import time
 import inspect
@@ -100,5 +101,8 @@ if __name__ == "__main__":
 
     if len(args.load) > 0:
         for obs in args.load:
+            if not obs.endswith('Observer'):
+                continue
             manager.start_observer(obs)
+
     rospy.spin()


### PR DESCRIPTION
Can now load observers at startup instead of calling a service at runtime (this option is still available). The command will look like 
```
rosrun rosgraph_monitor monitor --load ROSGraphObserver DummyObserver _desired_rossystem:=<path/to/file>test.rossystem
```